### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BobKerns/zabob-houdini/security/code-scanning/3](https://github.com/BobKerns/zabob-houdini/security/code-scanning/3)

To fix the problem, you should explicitly set the `permissions` key at the workflow or (each) job level. The minimal safe starting point is `contents: read`, which restricts the GITHUB_TOKEN to only the read permission on repository contents, meeting least privilege principles for jobs that do not need elevated write or administrative permissions.

The best fix is to add the following block at the top level of the workflow (right after `name:` and before `on:`). This applies to all jobs unless they have individual overrides, and avoids redundancy. If certain jobs require more permissions, they can be given a more permissive `permissions` block individually as needed.

The required change is to add:

```yaml
permissions:
  contents: read
```

just after `name: Tests` and before the `on:` key in `.github/workflows/test.yml`.

No methods, imports, or other definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
